### PR TITLE
Don't track `CGPGrey2` and `greysfavs`

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,8 +28,7 @@ from google.appengine.api import memcache
 import youtube_integration
 from database_tables import *
 
-GREY_CHANNELS = [ 'CGPGrey', 'CGPGrey2',
-'greysfavs']
+GREY_CHANNELS = [ 'CGPGrey']
 BRADY_CHANNELS = [ 'numberphile', 'Computerphile',
 'sixtysymbols', 'periodicvideos', 'nottinghamscience',
 'DeepSkyVideos', 'bibledex', 'wordsoftheworld',


### PR DESCRIPTION
[Pulling videos from **CGPGrey2** misrepresents Grey's video count](http://youtu.be/rMY0NgKXtCA?t=30s) since that channel doesn't contain any of his proper/educational videos.

This PR removes that as well as **greysfavs** so that the only videos of his that are counted are the ones on his primary channel.

/cc @nicktendo64
